### PR TITLE
Fix controller spawn error

### DIFF
--- a/fd_bringup/launch/fd.launch.py
+++ b/fd_bringup/launch/fd.launch.py
@@ -13,9 +13,13 @@
 # limitations under the License.
 
 from launch import LaunchDescription
-from launch.actions import DeclareLaunchArgument, ExecuteProcess
-from launch.substitutions import Command, FindExecutable
-from launch.substitutions import LaunchConfiguration, PathJoinSubstitution
+from launch.actions import DeclareLaunchArgument
+from launch.substitutions import (
+    Command,
+    FindExecutable,
+    LaunchConfiguration,
+    PathJoinSubstitution,
+)
 from launch_ros.actions import Node
 from launch_ros.substitutions import FindPackageShare
 
@@ -88,14 +92,16 @@ def generate_launch_description():
     load_controllers = []
     for controller in ['fd_controller', 'joint_state_broadcaster']:
         load_controllers += [
-            ExecuteProcess(
-                cmd=[
-                    'ros2 run controller_manager spawner' +
-                    f'--controller-manager /fd/controller_manager {controller}'
+            Node(
+                package='controller_manager',
+                executable='spawner',
+                namespace='fd',
+                arguments=[
+                    controller,
+                    '--controller-manager',
+                    '/fd/controller_manager',
                 ],
-                shell=True,
-                output='screen',
-            )
+            ),
         ]
 
     nodes = [


### PR DESCRIPTION
Fix #10 

This unexpected behavior was introduced in #9:

https://github.com/ICube-Robotics/forcedimension_ros2/blob/0db5e5cc87c7cb5304b021f6981a6951d8c6614f/fd_bringup/launch/fd.launch.py#L92-L95

So the command is expanded as:

```
ros2 run controller_manager spawner--controller-manager /fd/controller_manager fd_controller
```

Where a space is missing between `spawner` and `--controller-manager`.

I rewrite it using `Node` instead of `ExecuteProcess` in order to make code clearer and easier to debug.