### PR TITLE
Add missing effort controller dependency.

### DIFF
--- a/fd_hardware/package.xml
+++ b/fd_hardware/package.xml
@@ -16,6 +16,7 @@
   <depend>rclcpp</depend>
   <depend>rclcpp_lifecycle</depend>
   <depend>fd_sdk_vendor</depend>
+  <depend>effort_controllers</depend>
 
   <exec_depend>controller_manager</exec_depend>
   <exec_depend>xacro</exec_depend>


### PR DESCRIPTION
Ran into issues due to missing `ros-humble-effort-controllers`, so I've added that package as a dependency.