### PR TITLE
Disconnect device properly if controller manager is shutdown via Ctrl + C 

### DIFF
--- a/fd_hardware/include/fd_hardware/fd_effort_hi.hpp
+++ b/fd_hardware/include/fd_hardware/fd_effort_hi.hpp
@@ -35,6 +35,8 @@ class FDEffortHardwareInterface : public hardware_interface::SystemInterface
 public:
   RCLCPP_SHARED_PTR_DEFINITIONS(FDEffortHardwareInterface);
 
+  virtual ~FDEffortHardwareInterface();
+
   FD_HARDWARE_PUBLIC
   CallbackReturn on_init(const hardware_interface::HardwareInfo & info) override;
 

--- a/fd_hardware/src/fd_effort_hi.cpp
+++ b/fd_hardware/src/fd_effort_hi.cpp
@@ -35,6 +35,14 @@ using CallbackReturn = rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface
 
 namespace fd_hardware
 {
+
+FDEffortHardwareInterface::~FDEffortHardwareInterface()
+{
+  // If controller manager is shutdown via Ctrl + C, the on_deactivate methods won't be called.
+  // We need to call them here to ensure that the device is stopped and disconnected.
+  on_deactivate(rclcpp_lifecycle::State());
+}
+
 // ------------------------------------------------------------------------------------------
 CallbackReturn FDEffortHardwareInterface::on_init(
   const hardware_interface::HardwareInfo & info)


### PR DESCRIPTION
Currently shutting down controller manager via Ctrl+C won't call on_deactivate() method. The fd device will still operate with force enabled after killing the program. Although it's okay to manually deactivate force using the button the device, it's convenient to have the device automatically closed.

The workaround is adapted from https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/blob/e5ba31cd38c34076f95b25a047daaa16f7c3466c/ur_robot_driver/src/hardware_interface.cpp#L58C1-L63C2

Ideally this should be handled in ros2_control but there's still no update on their side, see https://github.com/ros-controls/ros2_control/issues/472.