### PR TITLE
Allow clutch only mode for omega6

### DIFF
--- a/fd_description/config/fd.config.xacro
+++ b/fd_description/config/fd.config.xacro
@@ -17,10 +17,12 @@
     <!-- Import and setup interface ros2_control description -->
     <xacro:include filename="$(find fd_description)/ros2_control/fd.r2c_hardware.xacro" />
     <xacro:fd_ros2_control
+        interface_id="-1"
         robot_id= "$(arg robot_id)"
         use_fake_hardware="$(arg use_fake_hardware)"
         use_orientation="$(arg use_orientation)"
     	orientation_is_actuated="$(arg use_orientation)"
         use_clutch="$(arg use_clutch)"
+        emulate_button="true"
     /> <!-- orientation_is_actuated = use_orientation for now (see HW impl.) -->
 </robot>

--- a/fd_hardware/src/fd_effort_hi.cpp
+++ b/fd_hardware/src/fd_effort_hi.cpp
@@ -343,6 +343,7 @@ hardware_interface::return_type FDEffortHardwareInterface::read(
   } else if (button_status == 0) {
     hw_button_state_[0] = 0.0;
   } else {
+    RCLCPP_ERROR(LOGGER, "Invalid button reading!");
     flag += -1;
   }
 


### PR DESCRIPTION
Add a 4th control mode:
1) position only (3 controlled DoF)
2) position + orientation (6 controlled DoF)
3)  position + orientation + clutch (7 controlled DoF)
4)   __NEW MODE:__ position + clutch (4 controlled DoF)