### PR TITLE
allow change effector mass and ignore rotations

### DIFF
--- a/fd_description/config/fd.config.xacro
+++ b/fd_description/config/fd.config.xacro
@@ -25,5 +25,11 @@
         ignore_orientation_readings="false"
         use_clutch="$(arg use_clutch)"
         emulate_button="true"
-    /> <!-- orientation_is_actuated = use_orientation for now (see HW impl.) -->
+        effector_mass="-1.0"
+    />
+
+    <!-- Default effector masses:
+        - 0.148 kg for the Omega 3 device
+        - 0.5 kg for the Omega 6 device
+    -->
 </robot>

--- a/fd_description/config/fd.config.xacro
+++ b/fd_description/config/fd.config.xacro
@@ -22,6 +22,7 @@
         use_fake_hardware="$(arg use_fake_hardware)"
         use_orientation="$(arg use_orientation)"
     	orientation_is_actuated="$(arg use_orientation)"
+        ignore_orientation_readings="false"
         use_clutch="$(arg use_clutch)"
         emulate_button="true"
     /> <!-- orientation_is_actuated = use_orientation for now (see HW impl.) -->

--- a/fd_description/ros2_control/fd.r2c_hardware.xacro
+++ b/fd_description/ros2_control/fd.r2c_hardware.xacro
@@ -2,7 +2,7 @@
 <robot xmlns:xacro="http://www.ros.org/wiki/xacro">
     <xacro:macro
         name="fd_ros2_control"
-        params="robot_id plugin_name:='FDHapticInterface' interface_id:='-1' use_fake_hardware:='false' use_orientation:='false' orientation_is_actuated:='false' use_clutch:='false' emulate_button:='false'">
+        params="robot_id plugin_name:='FDHapticInterface' interface_id:='-1' effector_mass:='-1.0' use_fake_hardware:='false' use_orientation:='false' orientation_is_actuated:='false' use_clutch:='false' emulate_button:='false'">
         <ros2_control name="${plugin_name}" type="system">
             <hardware>
                 <xacro:if value="${use_fake_hardware}">
@@ -13,6 +13,7 @@
                     <param name="interface_id">${interface_id}</param>
                     <param name="emulate_button">${emulate_button}</param>
                     <param name="inertia_interface_name">fd_inertia</param>
+                    <param name="effector_mass">${effector_mass}</param>
                 </xacro:unless>
             </hardware>
 

--- a/fd_description/ros2_control/fd.r2c_hardware.xacro
+++ b/fd_description/ros2_control/fd.r2c_hardware.xacro
@@ -2,7 +2,7 @@
 <robot xmlns:xacro="http://www.ros.org/wiki/xacro">
     <xacro:macro
         name="fd_ros2_control"
-        params="robot_id plugin_name:='FDHapticInterface' interface_id:='-1' effector_mass:='-1.0' use_fake_hardware:='false' use_orientation:='false' orientation_is_actuated:='false' use_clutch:='false' emulate_button:='false'">
+        params="robot_id plugin_name:='FDHapticInterface' interface_id:='-1' effector_mass:='-1.0' use_fake_hardware:='false' use_orientation:='false' orientation_is_actuated:='false' use_clutch:='false' emulate_button:='false' ignore_orientation_readings:='false'">
         <ros2_control name="${plugin_name}" type="system">
             <hardware>
                 <xacro:if value="${use_fake_hardware}">
@@ -14,6 +14,7 @@
                     <param name="emulate_button">${emulate_button}</param>
                     <param name="inertia_interface_name">fd_inertia</param>
                     <param name="effector_mass">${effector_mass}</param>
+                    <param name="ignore_orientation_readings">${ignore_orientation_readings}</param>
                 </xacro:unless>
             </hardware>
 

--- a/fd_hardware/include/fd_hardware/fd_effort_hi.hpp
+++ b/fd_hardware/include/fd_hardware/fd_effort_hi.hpp
@@ -68,6 +68,9 @@ private:
   /// If true, the button will be emulated from clutch joint (for omega 6 / sigma 7, see SDK doc)
   bool emulate_button_ = false;
 
+  // If true, the reading will emulate an omega 3 interface
+  bool ignore_orientation_ = false;
+
   /// Interface mass in Kg, not used if negative
   double effector_mass_ = -1.0;
 

--- a/fd_hardware/include/fd_hardware/fd_effort_hi.hpp
+++ b/fd_hardware/include/fd_hardware/fd_effort_hi.hpp
@@ -68,6 +68,9 @@ private:
   /// If true, the button will be emulated from clutch joint (for omega 6 / sigma 7, see SDK doc)
   bool emulate_button_ = false;
 
+  /// Interface mass in Kg, not used if negative
+  double effector_mass_ = -1.0;
+
   std::string inertia_interface_name_;
 
   // Store the command for the robot

--- a/fd_hardware/src/fd_effort_hi.cpp
+++ b/fd_hardware/src/fd_effort_hi.cpp
@@ -534,7 +534,7 @@ bool FDEffortHardwareInterface::connectToDevice()
       return false;
     }
 
-    ignore_orientation_ &= !dhdHasWrist(interface_ID_);
+    ignore_orientation_ |= !dhdHasWrist(interface_ID_);
     if (ignore_orientation_) {
       RCLCPP_INFO(LOGGER, "dhd : Orientation will be ignored !");
     }

--- a/fd_hardware/src/fd_effort_hi.cpp
+++ b/fd_hardware/src/fd_effort_hi.cpp
@@ -178,7 +178,7 @@ CallbackReturn FDEffortHardwareInterface::on_init(
 
   auto it_interface_mass = info_.hardware_parameters.find("effector_mass");
   if (it_interface_mass != info_.hardware_parameters.end()) {
-    effector_mass_ = hardware_interface::stod(it_interface_id->second);
+    effector_mass_ = hardware_interface::stod(it_interface_mass->second);
     RCLCPP_INFO(LOGGER, "Interface mass parameter found: %lf Kg", effector_mass_);
   } else {
     effector_mass_ = -1.0;


### PR DESCRIPTION
New features:
- change effector mass
   - __Use-case:__ custom end effector (e.g., added force torqe sensor).
   - __Implementation:__ parameter `effector_mass` in hardware interface.

- ignore orientation readings
   - __Use-case:__ you want to get the hardware interfaces for the orientation, but you don't want the orientation to change (useful in some teleoperation scenarios)
   - __Implementation:__ parameter `ignore_orientation_readings` in hardware interface.
