### PR TITLE
Integrated auto calibration process at startup

### DIFF
--- a/fd_bringup/launch/fd.launch.py
+++ b/fd_bringup/launch/fd.launch.py
@@ -29,6 +29,7 @@ def generate_launch_description():
     use_fake_hardware = LaunchConfiguration('use_fake_hardware')
     use_orientation = LaunchConfiguration('use_orientation')
     use_clutch = LaunchConfiguration('use_clutch')
+    auto_calibration = LaunchConfiguration('auto_calibration')
 
     # Get URDF via xacro
     robot_description_content = Command(
@@ -45,6 +46,7 @@ def generate_launch_description():
             ' use_fake_hardware:=', use_fake_hardware,
             ' use_orientation:=', use_orientation,
             ' use_clutch:=', use_clutch,
+            ' auto_calibration:=', auto_calibration,
         ]
     )
     robot_description = \
@@ -132,4 +134,8 @@ def generate_launch_description():
             'use_clutch',
             default_value='false',
             description='Enable clutch (read pos/vel/force and write force)'),
-        ] + nodes)
+        DeclareLaunchArgument(
+         'auto_calibration',
+         default_value='false',
+         description='Enable automatic calibration at startup'),
+        ]+ nodes)

--- a/fd_description/config/fd.config.xacro
+++ b/fd_description/config/fd.config.xacro
@@ -5,6 +5,7 @@
     <xacro:arg name="use_fake_hardware" default="false"/>
     <xacro:arg name="use_orientation" default="false"/>
     <xacro:arg name="use_clutch" default="false"/>
+    <xacro:arg name="auto_calibration" default="false"/>
 
     <!-- Import interface urdf file -->
     <xacro:include filename="$(find fd_description)/urdf/fd.urdf.xacro"/>
@@ -27,6 +28,7 @@
         use_clutch="$(arg use_clutch)"
         emulate_button="true"
         effector_mass="-1.0"
+        auto_calibrate="$(arg auto_calibration)"
     />
 
     <!-- Default effector masses:

--- a/fd_description/ros2_control/fd.r2c_hardware.xacro
+++ b/fd_description/ros2_control/fd.r2c_hardware.xacro
@@ -2,7 +2,7 @@
 <robot xmlns:xacro="http://www.ros.org/wiki/xacro">
     <xacro:macro
         name="fd_ros2_control"
-        params="robot_id plugin_name:='FDHapticInterface' interface_id:='-1' interface_sn:='-1' effector_mass:='-1.0' use_fake_hardware:='false' use_orientation:='false' orientation_is_actuated:='false' use_clutch:='false' emulate_button:='false' ignore_orientation_readings:='false'">
+        params="robot_id plugin_name:='FDHapticInterface' interface_id:='-1' interface_sn:='-1' effector_mass:='-1.0' use_fake_hardware:='false' use_orientation:='false' orientation_is_actuated:='false' use_clutch:='false' emulate_button:='false' ignore_orientation_readings:='false' auto_calibrate:='false'">
         <ros2_control name="${plugin_name}" type="system">
             <hardware>
                 <xacro:if value="${use_fake_hardware}">
@@ -16,6 +16,7 @@
                     <param name="inertia_interface_name">${robot_id}_inertia</param>
                     <param name="effector_mass">${effector_mass}</param>
                     <param name="ignore_orientation_readings">${ignore_orientation_readings}</param>
+                    <param name="auto_calibrate">${auto_calibrate}</param>
                 </xacro:unless>
             </hardware>
 

--- a/fd_hardware/include/fd_hardware/fd_effort_hi.hpp
+++ b/fd_hardware/include/fd_hardware/fd_effort_hi.hpp
@@ -74,6 +74,9 @@ private:
   // If true, the reading will emulate an omega 3 interface
   bool ignore_orientation_ = false;
 
+  // If true, the device will be auto-calibrated on connect
+  bool auto_calibrate_ = false;
+
   /// Interface mass in Kg, not used if negative
   double effector_mass_ = -1.0;
 

--- a/fd_hardware/src/fd_effort_hi.cpp
+++ b/fd_hardware/src/fd_effort_hi.cpp
@@ -528,11 +528,11 @@ bool FDEffortHardwareInterface::connectToDevice()
 
       if (drdOpenID(interface_ID_) < 0) {
         RCLCPP_WARN(LOGGER,
-          "drd : drdOpenID() failed, skipping auto-init: %s", drdErrorGetLastStr());
+          "drd : drdOpenID() failed, skipping auto-init: %s", dhdErrorGetLastStr());
       } else {
         if (drdAutoInit() < 0) {
           RCLCPP_WARN(LOGGER,
-            "drd : drdAutoInit() failed (non-fatal): %s", drdErrorGetLastStr());
+            "drd : drdAutoInit() failed (non-fatal): %s", dhdErrorGetLastStr());
         } else {
           RCLCPP_INFO(LOGGER, "drd : Automatic initialization complete.");
         }


### PR DESCRIPTION
- Added launch argument in fd_bringup and fd_description. This triggers the calibration at startup (defaults to false to avoid breaking changes)
- Using drdAutoInit() in fd_hardware to run the calibration using the SDK command.
